### PR TITLE
Option to auto-close tab

### DIFF
--- a/server/historyLifecycle.test.ts
+++ b/server/historyLifecycle.test.ts
@@ -20,6 +20,7 @@ interface SessionResult {
   version: number;
   history: string[];
   outputBehavior: "allow" | "deny";
+  autoCloseOnSubmit: boolean;
 }
 
 async function waitForServerUrl(getStderr: () => string): Promise<string> {
@@ -37,6 +38,7 @@ async function runSession(args: {
   plan: string;
   env: Record<string, string>;
   hookEvent: Record<string, unknown>;
+  beforeDecision?: (baseUrl: string) => Promise<void>;
 }): Promise<SessionResult> {
   const child = spawn(process.execPath, ["run", "server/index.ts"], {
     cwd: join(import.meta.dir, ".."),
@@ -69,7 +71,15 @@ async function runSession(args: {
     const baseUrl = await waitForServerUrl(() => stderr);
 
     const planRes = await fetch(`${baseUrl}/api/plan`);
-    const planJson = (await planRes.json()) as { version: number; history: string[] };
+    const planJson = (await planRes.json()) as {
+      version: number;
+      history: string[];
+      preferences?: { autoCloseOnSubmit?: boolean };
+    };
+
+    if (args.beforeDecision) {
+      await args.beforeDecision(baseUrl);
+    }
 
     if (args.decision === "approve") {
       await fetch(`${baseUrl}/api/approve`, { method: "POST" });
@@ -95,6 +105,7 @@ async function runSession(args: {
       version: planJson.version,
       history: planJson.history,
       outputBehavior: output.hookSpecificOutput.decision.behavior,
+      autoCloseOnSubmit: planJson.preferences?.autoCloseOnSubmit ?? false,
     };
   } finally {
     if (child.exitCode === null) {
@@ -155,6 +166,7 @@ describe("history lifecycle", () => {
       expect(run1.version).toBe(1);
       expect(run1.history).toEqual([]);
       expect(run1.outputBehavior).toBe("deny");
+      expect(run1.autoCloseOnSubmit).toBe(false);
 
       expect(existsSync(historyDir)).toBe(true);
       expect(readdirSync(historyDir).sort()).toEqual(["v1.md"]);
@@ -164,6 +176,7 @@ describe("history lifecycle", () => {
       expect(run2.version).toBe(2);
       expect(run2.history).toEqual(["Plan v1"]);
       expect(run2.outputBehavior).toBe("deny");
+      expect(run2.autoCloseOnSubmit).toBe(false);
 
       expect(readdirSync(historyDir).sort()).toEqual(["v1.md", "v2.md"]);
       expect(readFileSync(join(historyDir, "v2.md"), "utf8")).toBe("Plan v2");
@@ -172,8 +185,96 @@ describe("history lifecycle", () => {
       expect(run3.version).toBe(3);
       expect(run3.history).toEqual(["Plan v1", "Plan v2"]);
       expect(run3.outputBehavior).toBe("allow");
+      expect(run3.autoCloseOnSubmit).toBe(false);
 
       expect(existsSync(historyDir)).toBe(false);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  }, 30000);
+
+  test("persists auto-close preference across sessions", async () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "open-plan-annotator-test-"));
+    const fakeBin = join(tempRoot, "bin");
+    const configHome = join(tempRoot, "config");
+
+    try {
+      mkdirSync(fakeBin, { recursive: true });
+      mkdirSync(configHome, { recursive: true });
+
+      const openShim = join(fakeBin, "open");
+      writeFileSync(openShim, "#!/bin/sh\nexit 0\n", "utf8");
+      chmodSync(openShim, 0o755);
+
+      const xdgOpenShim = join(fakeBin, "xdg-open");
+      writeFileSync(xdgOpenShim, "#!/bin/sh\nexit 0\n", "utf8");
+      chmodSync(xdgOpenShim, 0o755);
+
+      const cmdShim = join(fakeBin, "cmd");
+      writeFileSync(cmdShim, "#!/bin/sh\nexit 0\n", "utf8");
+      chmodSync(cmdShim, 0o755);
+
+      const cmdExeShim = join(fakeBin, "cmd.cmd");
+      writeFileSync(cmdExeShim, "@echo off\r\nexit /b 0\r\n", "utf8");
+
+      const hookEvent = {
+        transcript_path: "/tmp/shared-preferences.jsonl",
+        session_id: "session-pref",
+        cwd: "/repo",
+        permission_mode: "acceptEdits",
+        hook_event_name: "PermissionRequest",
+        tool_name: "Write",
+        tool_use_id: "tool-pref",
+      };
+
+      const preferencesPath = join(configHome, "open-plan-annotator", "preferences.json");
+
+      const env = {
+        NODE_ENV: "test",
+        XDG_CONFIG_HOME: configHome,
+        PATH: `${fakeBin}${delimiter}${process.env.PATH ?? ""}`,
+      };
+
+      const firstRun = await runSession({
+        decision: "approve",
+        plan: "Plan with preferences v1",
+        env,
+        hookEvent,
+        beforeDecision: async (baseUrl) => {
+          const updateRes = await fetch(`${baseUrl}/api/settings`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ autoCloseOnSubmit: true }),
+          });
+
+          expect(updateRes.ok).toBe(true);
+
+          const invalidRes = await fetch(`${baseUrl}/api/settings`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ autoCloseOnSubmit: "yes" }),
+          });
+
+          expect(invalidRes.status).toBe(400);
+        },
+      });
+
+      expect(firstRun.autoCloseOnSubmit).toBe(false);
+      expect(firstRun.outputBehavior).toBe("allow");
+      expect(existsSync(preferencesPath)).toBe(true);
+      expect(JSON.parse(readFileSync(preferencesPath, "utf8")) as { autoCloseOnSubmit: boolean }).toEqual({
+        autoCloseOnSubmit: true,
+      });
+
+      const secondRun = await runSession({
+        decision: "approve",
+        plan: "Plan with preferences v2",
+        env,
+        hookEvent,
+      });
+
+      expect(secondRun.autoCloseOnSubmit).toBe(true);
+      expect(secondRun.outputBehavior).toBe("allow");
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/server/types.ts
+++ b/server/types.ts
@@ -21,6 +21,10 @@ export interface Annotation {
   createdAt: string;
 }
 
+export interface UserPreferences {
+  autoCloseOnSubmit: boolean;
+}
+
 export interface HookOutput {
   hookSpecificOutput: {
     hookEventName: "PermissionRequest";
@@ -32,8 +36,10 @@ export interface ServerState {
   planContent: string;
   planVersion: number;
   planHistory: string[];
+  preferences: UserPreferences;
   htmlContent: string;
   resolveDecision: ((decision: ServerDecision) => void) | null;
+  persistPreferences: (preferences: UserPreferences) => Promise<void>;
 }
 
 export interface ServerDecision {

--- a/ui/components/Header.tsx
+++ b/ui/components/Header.tsx
@@ -8,10 +8,24 @@ interface HeaderProps {
   deny: () => void;
   isPending: boolean;
   decided: boolean;
+  autoCloseOnSubmit: boolean;
+  onToggleAutoClose: (nextValue: boolean) => void;
+  isSavingAutoClose: boolean;
 }
 
-export function Header({ annotations, version, approve, deny, isPending, decided }: HeaderProps) {
+export function Header({
+  annotations,
+  version,
+  approve,
+  deny,
+  isPending,
+  decided,
+  autoCloseOnSubmit,
+  onToggleAutoClose,
+  isSavingAutoClose,
+}: HeaderProps) {
   const { dark, toggle } = useTheme();
+  const isAutoCloseDisabled = isPending || isSavingAutoClose;
 
   if (decided) {
     return (
@@ -105,6 +119,27 @@ export function Header({ annotations, version, approve, deny, isPending, decided
           </button>
 
           <div className="w-px h-5 bg-rule mx-2" />
+
+          <div className="flex items-center gap-2 mr-1">
+            <span className="text-[12px] font-medium text-ink-tertiary">Auto-close</span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={autoCloseOnSubmit}
+              aria-label="Auto-close tab after submitting"
+              onClick={() => onToggleAutoClose(!autoCloseOnSubmit)}
+              disabled={isAutoCloseDisabled}
+              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors focus-visible:ring-2 focus-visible:ring-accent/50 disabled:opacity-40 disabled:cursor-not-allowed ${
+                autoCloseOnSubmit ? "bg-accent/70" : "bg-ink/15"
+              }`}
+            >
+              <span
+                className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
+                  autoCloseOnSubmit ? "translate-x-5" : "translate-x-0.5"
+                }`}
+              />
+            </button>
+          </div>
 
           <button
             type="button"

--- a/ui/hooks/usePlan.ts
+++ b/ui/hooks/usePlan.ts
@@ -5,6 +5,9 @@ interface PlanData {
   plan: string;
   version: number;
   history: string[];
+  preferences?: {
+    autoCloseOnSubmit?: boolean;
+  };
 }
 
 export function usePlan() {
@@ -35,6 +38,7 @@ export function usePlan() {
     planHash,
     version: data?.version ?? 1,
     history: data?.history ?? [],
+    autoCloseOnSubmit: data?.preferences?.autoCloseOnSubmit ?? false,
     isLoading,
     error,
   };


### PR DESCRIPTION
### Description

Introduce a switch to automatically close the tab after you have finished reviewing a plan.

When trying the plugin I found myself accumulating tabs, so I thought it would be nice to have a little persisted toggle to optionally auto-close after you submit your feedback or approval.

<img width="1727" height="358" alt="Screenshot 2026-02-25 at 15 01 04" src="https://github.com/user-attachments/assets/71b5f231-f823-4d0e-a9fb-2f8179ba25e8" />


### Additional context

It should be noted that this has been entirely generated and is probably a poor quality contribution. I've got a personal project that is taking up free time at the minute, so it might be until next weekend until I can spend more time on refining it.

Things like where we persist the auto-close decision perhaps should be in local-storage rather than in some location on disk.